### PR TITLE
fix: Change into correct directory in Go Build and test action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,10 +26,17 @@ jobs:
       
     - name: Install dependencies
       run: |
-        go get . 
+        cd ./resource-cel-validator
+        go get .
+        cd ../tests
+        go get -t .
 
     - name: Build
-      run: go build -v ./...
+      run: | 
+        cd ./resource-cel-validator
+        go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: | 
+        cd ./tests
+        go test -v ./...


### PR DESCRIPTION
Signed-off-by: Vyom-Yadav [jackhammervyom@gmail.com](mailto:jackhammervyom@gmail.com)

---

This PR:

- Modifies action step by `cd`ing into the correct directory