### PR TITLE
fix: Remove go version 1.18 from matrix and set fail-fast to false

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,12 +7,12 @@ on:
     branches: [ "main" ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [ '1.18', '1.19', '1.20.x' ]
+        go-version: [ '1.19', '1.20.x' ]
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Signed-off-by: Vyom-Yadav [jackhammervyom@gmail.com](mailto:jackhammervyom@gmail.com)

---

This PR:

- Removes go version 1.18 from supported versions as many packages use `atomic.Bool` introduces in 1.19
- Set set fail-fast to false