### PR TITLE
fix: Add caching to setup go action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,10 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        
+        check-latest: true
+        cache: true
+        cache-dependency-path: '**/go.sum'
+
     - name: Display Go version
       run: go version
       


### PR DESCRIPTION
Signed-off-by: Vyom-Yadav [jackhammervyom@gmail.com](mailto:jackhammervyom@gmail.com)

---

This PR:

- Modifies `cache-dependency-path` to cache dependencies.
- Set `check-latest` to true